### PR TITLE
Misc fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "discord_bot",
-  "version": "0.8.6",
+  "version": "0.9.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2541,9 +2541,9 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-gyp": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "express": "^4.17.1",
     "fluent-ffmpeg": "^2.1.2",
     "nconf": "^0.10.0",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "node-gyp": "^7.1.0",
     "node-witai-speech": "^1.0.2",
     "ogg.js": "^0.1.0",

--- a/src/DiscordBot.js
+++ b/src/DiscordBot.js
@@ -40,7 +40,7 @@ class DiscordBot {
       this.safeSymbol = `\\${this.symbol}`;
     }
     this.adminWordRegex = new RegExp(`^${this.safeSymbol}(${this.adminWords.join('|')})(.*)$`)
-    this.keyWordRegex = new RegExp(`${this.safeSymbol}([a-z0-9_]+)(.*)`)
+    this.keyWordRegex = new RegExp(`[^@]${this.safeSymbol}([a-z0-9_]+)(.*)`)
   }
 
   connect() {

--- a/src/VoiceQueue.js
+++ b/src/VoiceQueue.js
@@ -53,7 +53,11 @@ class VoiceQueue {
     // Give it time to finish playing, then leave, or catch errors
     setTimeout(() => {
       try {
-        this.channel.leave()
+        if(this.playQueue.length == 0) {
+          this.channel.leave()
+        } else {
+          this.log(`Was leaving channel, but there were still things to play`)
+        }
       } catch(err) {
         this.log(`Error leaving channel: ${err.message}`)
       }


### PR DESCRIPTION
@ mentions translate to: <@!123456> in discord, which would trigger ! keywords, so we should filter that out.

Playing a clip while it is in the timeout before leaving (so that the powerdown sound plays) could cause the bot to not re-connect to channel to continue playing the queue, so instead, only leave the channel if the queue is in fact empty. (Might not entirely fix it)